### PR TITLE
Adds natural compatibility with Unix-like systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ pip install pyinstaller
 
 ## Running the tests
 
+### Linux, Mac OS X, BSD and most OSes except Windows
+Turn script executable:
+
+```
+chmod +x photo-organizer.py
+```
+
+Call script inside a folder with photos:
+
+```
+./photo-organizer.py .
+```
+
+### Windows
+
 To run a test, call the script inside a folder with photos.
 
 ```

--- a/photo-organizer.py
+++ b/photo-organizer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import shutil
 from datetime import datetime


### PR DESCRIPTION
On Unix-like sistems (Linux, Mac OS X, *BSD...) if you add a hashbang (`#!`) the script will work like a executable, in case of Python 3 is:
```sh
#!/usr/bin/env python3
```
So *nix users can run this script, as:

```
photo-organizer.py [Path]
```