### PR TITLE
Changes and corrections in files treatment

### DIFF
--- a/photo-organizer.py
+++ b/photo-organizer.py
@@ -6,7 +6,7 @@ from PIL import Image
 
 
 class PhotoOrganizer:
-    extensions = ['jpg', 'jpeg', 'JPG', 'JPEG']
+    extensions = ['jpg', 'jpeg', 'png']
 
     def folder_path_from_photo_date(self, file):
         date = self.photo_shooting_date(file)
@@ -30,7 +30,8 @@ class PhotoOrganizer:
 
     def organize(self):
         photos = [
-            filename for filename in os.listdir('.') if any(filename.endswith(ext) for ext in self.extensions)
+            filename for filename in os.listdir('.')
+                if os.path.isfile(filename) and any(filename.lower().endswith('.' + ext.lower()) for ext in self.extensions)
         ]
         for filename in photos:
             self.move_photo(filename)

--- a/photo-organizer.py
+++ b/photo-organizer.py
@@ -6,6 +6,7 @@ from PIL import Image
 
 
 class PhotoOrganizer:
+    DATETIME_EXIF_INFO_ID = 36867
     extensions = ['jpg', 'jpeg', 'png']
 
     def folder_path_from_photo_date(self, file):
@@ -13,13 +14,16 @@ class PhotoOrganizer:
         return date.strftime('%Y') + '/' + date.strftime('%Y-%m-%d')
 
     def photo_shooting_date(self, file):
+        date = None
         photo = Image.open(file)
-        info = photo._getexif()
-        date = datetime.fromtimestamp(os.path.getmtime(file))
-        if info:
-            if 36867 in info:
-                date = info[36867]
-                date = datetime.strptime(date, '%Y:%m:%d %H:%M:%S')
+        if hasattr(photo, '_getexif'):
+            info = photo._getexif()
+            if info:
+                if self.DATETIME_EXIF_INFO_ID in info:
+                    date = info[self.DATETIME_EXIF_INFO_ID]
+                    date = datetime.strptime(date, '%Y:%m:%d %H:%M:%S')
+        if date is None:
+            date = datetime.fromtimestamp(os.path.getmtime(file))
         return date
 
     def move_photo(self, file):


### PR DESCRIPTION
- Process files only cause if there is some directory with a filtered extension suffix (eg: images-jpg), it'll trigger an error.

- Added a "." before the extension comparison to filter extensions correctly.

- Process file extensions regardless extension case, so it's no longer needed specifying upper and lowercase extensions in extension filter list (useful mainly in Unix filesystems).